### PR TITLE
Add: [Server] EDCB 対応を追加

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,8 +8,18 @@
         # 有効にした場合、表示されるログが増える
         'debug': True,
 
+        # バックエンド
+        'backend': 'Mirakurun',
+
         # Mirakurun の URL
         'mirakurun_url': 'http://192.168.1.11:40772',
+
+        # EDCB の接続先ホスト名
+        # 空のときはローカルに接続
+        'edcb_host': '',
+
+        # EDCB の接続先ポート
+        'edcb_port': 4510,
     },
 
     # ライブストリームの設定

--- a/server/app/models/Channels.py
+++ b/server/app/models/Channels.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from app.constants import CONFIG
 from app.utils import ZenkakuToHankaku
+from app.utils.EDCB import EDCBUtil, CtrlCmdUtil
 
 
 class Channels(models.Model):
@@ -29,6 +30,83 @@ class Channels(models.Model):
     @classmethod
     async def update(cls) -> None:
         """チャンネル情報を更新する"""
+
+        if CONFIG['general']['backend'] == 'EDCB':
+            cmd = CtrlCmdUtil()
+            if CONFIG['general']['edcb_host']:
+                cmd.setNWSetting(CONFIG['general']['edcb_host'], CONFIG['general']['edcb_port'])
+
+            # リモコン番号が取得できない場合に備える
+            db_remocon_ids = {channel.id: channel.remocon_id for channel in await Channels.all()}
+            await Channels.all().delete()
+
+            # sendEnumService() の情報源は番組表。期限切れなどで番組情報が1つもないサービスについては取得できないので注意
+            # あればラッキー程度の情報と考えてほしい
+            epg_services = await cmd.sendEnumService() or []
+            services = await cmd.sendFileCopy('ChSet5.txt')
+            if services is None:
+                services = []
+            else:
+                services = EDCBUtil.parseChSet5(EDCBUtil.convertBytesToString(services))
+                # 枝番処理がミスらないようソートしておく
+                services.sort(key = lambda a: (a['onid'] << 16) | a['sid'])
+
+            last_network_id = -1
+            same_network_id_count = 0
+            last_network_remocon_id = 0
+            remocon_id_counts = {}
+
+            for service in services:
+                if service['service_type'] != 1:
+                    continue
+                nid = service['onid']
+                sid = service['sid']
+                channel = Channels()
+                channel.id = f'NID{nid}-SID{sid:03d}'
+                channel.service_id = sid
+                channel.network_id = nid
+                channel.transport_stream_id = service['tsid']
+                channel.remocon_id = None
+                channel.channel_name = ZenkakuToHankaku(service['service_name']).replace('：', ':')
+                # TODO: TSInformation あたりの情報を使いたい
+                channel.channel_type = 'BS' if nid == 4 else 'CS' if nid == 6 or nid == 7 else 'SKY' if nid == 1 or nid == 3 or nid == 10 else 'GR'
+                channel.channel_force = None
+                channel.channel_comment = None
+
+                if channel.channel_type == 'GR':
+                    epg_service = next(filter(lambda a: a['onid'] == nid and a['sid'] == sid, epg_services), None)
+                    if epg_service is not None:
+                        channel.remocon_id = epg_service['remote_control_key_id']
+                    else:
+                        channel.remocon_id = db_remocon_ids.get(channel.id)
+
+                    if last_network_id != nid:
+                        last_network_id = nid
+                        same_network_id_count = 1
+                        # リモコン番号が不明のときはとりあえず 0 とする
+                        last_network_remocon_id = 0 if channel.remocon_id is None else channel.remocon_id
+                        remocon_id_counts.setdefault(last_network_remocon_id, 0)
+                        remocon_id_counts[last_network_remocon_id] += 1
+                    else:
+                        same_network_id_count += 1
+                    channel.channel_number = str(last_network_remocon_id).zfill(2) + str(same_network_id_count)
+                    # 枝番処理
+                    if remocon_id_counts[last_network_remocon_id] > 1:
+                        channel.channel_number += '-' + str(remocon_id_counts[last_network_remocon_id])
+                else:
+                    channel.channel_number = str(sid).zfill(3)
+
+                channel.channel_id = channel.channel_type.lower() + channel.channel_number
+
+                if 0x7880 <= nid <= 0x7fef:
+                    channel.is_subchannel = (sid & 0x0187) != 0
+                elif nid == 4:
+                    channel.is_subchannel = sid in [102, 104, 142, 143, 152, 153, 162, 163, 172, 173, 182, 183]
+                else:
+                    channel.is_subchannel = False
+
+                await channel.save()
+            return
 
         # 既にデータベースにチャンネル情報が存在する場合は一旦全て削除する
         await Channels.all().delete()

--- a/server/app/models/LiveStream.py
+++ b/server/app/models/LiveStream.py
@@ -90,6 +90,16 @@ class LiveStream():
         # (チャンネルID)-(映像の品質) で一意な ID になる
         self.livestream_id:str = f'{self.channel_id}-{self.quality}'
 
+        # ライブストリームの整数の ID を設定
+        self.int_id:int = 0
+        int_ids = [livestream.int_id for livestream in self.__instances.values()]
+        int_ids.sort()
+        # 自身を含むので結果は 1 以上になる
+        for i in int_ids:
+            if self.int_id != i:
+                break
+            self.int_id += 1
+
 
     @classmethod
     def getAllLiveStream(cls) -> list:

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -15,11 +15,16 @@ class Config(BaseModel):
 
     class General(BaseModel):
         debug: bool
+        backend: str
         mirakurun_url: AnyHttpUrl
+        edcb_host: str
+        edcb_port: str
         # Mirakurun にアクセスできるかをチェック
         # 試しにリクエストを送り、200 (OK) が返ってきたときだけ有効な URL とみなす
         @validator('mirakurun_url')
-        def check_mirakurun_url(cls, mirakurun_url):
+        def check_mirakurun_url(cls, mirakurun_url, values):
+            if 'backend' in values and values['backend'] != 'Mirakurun':
+                return mirakurun_url
             try:
                 response = requests.get(f'{mirakurun_url}/api/version', timeout=3)
             except requests.exceptions.ConnectionError:

--- a/server/app/tasks/LiveEncodingTask.py
+++ b/server/app/tasks/LiveEncodingTask.py
@@ -233,14 +233,16 @@ class LiveEncodingTask():
                 if nwtv_process_id is not None or time.monotonic() >= set_ch_timeout:
                     break
                 time.sleep(0.5)
-            if nwtv_process_id is not None:
+            if nwtv_process_id is None:
+                # 失敗。成功時は sendNwTVIDClose() するか予約などに割り込まれるまで起動しつづけるので注意
+                nwtv_id = None
+            else:
                 nwtv_path = RunAwait(EDCBUtil.findNwTVStreamPath(nwtv_id, nwtv_process_id))
                 # 少し古い (2021 年 6 月以前) EDCB はパイプの待ち受け再開に時間がかかるので少し待つとよい
                 # time.sleep(2)
             if nwtv_path is None:
                 # 失敗だがこの後どうすればいいか知らないので開けなさそうな名前を入れておく
                 nwtv_path = '__error__'
-                nwtv_id = None
 
             ast = subprocess.Popen(
                 [LIBRARY_PATH['arib-subtitle-timedmetadater'], '-i', nwtv_path],

--- a/server/app/tasks/LiveEncodingTask.py
+++ b/server/app/tasks/LiveEncodingTask.py
@@ -10,6 +10,7 @@ from app.models import LiveStream
 from app.models import Programs
 from app.utils import Logging
 from app.utils import RunAwait
+from app.utils.EDCB import EDCBUtil, CtrlCmdUtil
 
 
 class LiveEncodingTask():
@@ -206,21 +207,57 @@ class LiveEncodingTask():
         if program_present.video_resolution == '480i' and int(quality[:-1]) > 480:
             quality = '480p'
 
-        # Mirakurun 形式のサービス ID
-        # NID と SID を 5 桁でゼロ埋めした上で int に変換する
-        mirakurun_service_id = int(str(network_id).zfill(5) + str(service_id).zfill(5))
-        # Mirakurun API の URL を作成
-        mirakurun_stream_api_url = f'{CONFIG["general"]["mirakurun_url"]}/api/services/{mirakurun_service_id}/stream'
+        if CONFIG['general']['backend'] == 'EDCB':
+            cmd = CtrlCmdUtil()
+            if CONFIG['general']['edcb_host']:
+                cmd.setNWSetting(CONFIG['general']['edcb_host'], CONFIG['general']['edcb_port'])
+            set_ch_info = {}
+            # これを False にすれば起動確認とプロセス ID の取得ができる
+            set_ch_info['use_sid'] = True
+            set_ch_info['onid'] = network_id
+            set_ch_info['tsid'] = channel.transport_stream_id
+            set_ch_info['sid'] = service_id
+            set_ch_info['use_bon_ch'] = True
+            # NetworkTV モードのチューナーを識別する任意の整数
+            # ほかのロケフリ系アプリと重複しないように増分してある
+            nwtv_id = livestream.int_id + 500
+            set_ch_info['space_or_id'] = nwtv_id
+            # TCP 送信を有効にする
+            set_ch_info['ch_or_mode'] = 2
+            # 起動または同一 ID のチャンネル変更
+            nwtv_path = None
+            nwtv_process_id = RunAwait(cmd.sendNwTVIDSetCh(set_ch_info))
+            if nwtv_process_id is not None:
+                nwtv_path = RunAwait(EDCBUtil.findNwTVStreamPath(nwtv_id, nwtv_process_id))
+                # 少し古い (2021 年 6 月以前) EDCB はパイプの待ち受け再開に時間がかかるので少し待つとよい
+                # time.sleep(2)
+            if nwtv_path is None:
+                # 失敗だがこの後どうすればいいか知らないので開けなさそうな名前を入れておく
+                nwtv_path = '__error__'
+                nwtv_id = None
 
-        # ***** arib-subtitle-timedmetadater プロセスの作成と実行 *****
+            ast = subprocess.Popen(
+                [LIBRARY_PATH['arib-subtitle-timedmetadater'], '-i', nwtv_path],
+                stdout = subprocess.PIPE,  # FFmpeg に繋ぐ
+                creationflags = (subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0),  # conhost を開かない
+            )
 
-        # arib-subtitle-timedmetadater
-        ## プロセスを非同期で作成・実行
-        ast = subprocess.Popen(
-            [LIBRARY_PATH['arib-subtitle-timedmetadater'], '--http', mirakurun_stream_api_url],
-            stdout=subprocess.PIPE,  # FFmpeg に繋ぐ
-            creationflags=(subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0),  # conhost を開かない
-        )
+        else:
+            # Mirakurun 形式のサービス ID
+            # NID と SID を 5 桁でゼロ埋めした上で int に変換する
+            mirakurun_service_id = int(str(network_id).zfill(5) + str(service_id).zfill(5))
+            # Mirakurun API の URL を作成
+            mirakurun_stream_api_url = f'{CONFIG["general"]["mirakurun_url"]}/api/services/{mirakurun_service_id}/stream'
+
+            # ***** arib-subtitle-timedmetadater プロセスの作成と実行 *****
+
+            # arib-subtitle-timedmetadater
+            ## プロセスを非同期で作成・実行
+            ast = subprocess.Popen(
+                [LIBRARY_PATH['arib-subtitle-timedmetadater'], '--http', mirakurun_stream_api_url],
+                stdout=subprocess.PIPE,  # FFmpeg に繋ぐ
+                creationflags=(subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0),  # conhost を開かない
+            )
 
         # ***** エンコーダープロセスの作成と実行 *****
 
@@ -501,6 +538,11 @@ class LiveEncodingTask():
         # 明示的にプロセスを終了する
         ast.kill()
         encoder.kill()
+
+        if CONFIG['general']['backend'] == 'EDCB':
+            if nwtv_id is not None:
+                # ここで閉じずに次のタスクにうまく引き継げば再利用もできるはず
+                RunAwait(cmd.sendNwTVIDClose(nwtv_id))
 
         # エンコードタスクを再起動する（エンコーダーの再起動が必要な場合）
         if is_restart_required is True:

--- a/server/app/utils/EDCB.py
+++ b/server/app/utils/EDCB.py
@@ -1,0 +1,794 @@
+
+import asyncio
+import datetime
+import glob
+import re
+import time
+from typing import Callable, Optional
+
+
+class EDCBUtil:
+    """ EDCB に関連する雑多なユーティリティ """
+
+    @staticmethod
+    def convertBytesToString(buf) -> str:
+        """ BOM に基づいて Bytes データを文字列に変換する """
+        if len(buf) == 0:
+            return ''
+        elif len(buf) >= 2 and buf[0] == 0xff and buf[1] == 0xfe:
+            return str(memoryview(buf)[2:], 'utf_16_le', 'replace')
+        elif len(buf) >= 3 and buf[0] == 0xef and buf[1] == 0xbb and buf[2] == 0xbf:
+            return str(memoryview(buf)[3:], 'utf_8', 'replace')
+        else:
+            return str(buf, 'cp932', 'replace')
+
+    @staticmethod
+    def parseChSet5(s: str) -> list:
+        """ ChSet5.txt を解析する """
+        v = []
+        for line in s.splitlines():
+            a = line.split('\t')
+            if len(a) >= 9:
+                e: dict = {}
+                try:
+                    e['service_name'] = a[0]
+                    e['network_name'] = a[1]
+                    e['onid'] = int(a[2])
+                    e['tsid'] = int(a[3])
+                    e['sid'] = int(a[4])
+                    e['service_type'] = int(a[5])
+                    e['partial_flag'] = int(a[6]) != 0
+                    e['epg_cap_flag'] = int(a[7]) != 0
+                    e['search_flag'] = int(a[8]) != 0
+                    v.append(e)
+                except:
+                    pass
+        return v
+
+    @staticmethod
+    def getLogoIDFromLogoDataIni(s: str, onid: int, sid: int) -> int:
+        """ LogoData.ini をもとにロゴ識別を取得する。失敗のとき負値を返す """
+        target = f'{onid:04X}{sid:04X}'
+        for line in s.splitlines():
+            kv = line.split('=', 1)
+            if len(kv) == 2 and kv[0].strip().upper() == target:
+                try:
+                    return int(kv[1].strip())
+                except:
+                    break
+        return -1
+
+    @staticmethod
+    def getLogoFileNameFromDirectoryIndex(s: str, onid: int, logo_id: int, logo_type: int) -> Optional[str]:
+        """ ファイルリストをもとにロゴファイル名を取得する """
+        target = f'{onid:04X}_{logo_id:03X}_'
+        target_type = f'_{logo_type:02d}.'
+        for line in s.splitlines():
+            a = line.split(' ', 3)
+            if len(a) == 4:
+                name = a[3]
+                if len(name) >= 16 and name[0:9].upper() == target and name[12:16] == target_type:
+                    return name
+        return None
+
+    @staticmethod
+    def parseProgramExtendedText(s: str) -> dict:
+        """ 詳細情報テキストを解析して項目ごとの辞書を返す """
+        s = s.replace('\r', '')
+        v = {}
+        head = ''
+        i = 0
+        while True:
+            if i == 0 and s.startswith('- '):
+                j = 2
+            elif (j := s.find('\n- ', i)) >= 0:
+                v[head] = s[(0 if i == 0 else i + 1):j + 1]
+                j += 3
+            else:
+                if len(s) != 0:
+                    v[head] = s[(0 if i == 0 else i + 1):]
+                break
+            i = s.find('\n', j)
+            if i < 0:
+                v[s[j:]] = ''
+                break
+            head = s[j:i]
+        return v
+
+    @staticmethod
+    async def findNwTVStreamPath(nwtv_id: int, process_id: int, timeout_sec: float = 10.) -> Optional[str]:
+        """ システムに存在する NetworkTV モードのストリームのパイプのパスを見つける """
+        while timeout_sec > 0.:
+            ff = glob.glob('\\\\.\\pipe\\SendTSTCP_*_' + str(process_id))
+            if len(ff) > 0:
+                path = ff[0]
+                # 安全のため検査
+                if re.fullmatch(r'\\\\\.\\PIPE\\SENDTSTCP_[0-9]+_' + str(process_id), path.upper()) is None:
+                    return None
+                return path
+            # たいてい glob() で見つかるが、環境により見つからないことがあるらしいので実際に開いて見つける
+            # ポートは 0 から 9 のあいだと仮定
+            for port in range(10):
+                try:
+                    path = '\\\\.\\pipe\\SendTSTCP_' + str(port) + '_' + str(process_id)
+                    with open(path, mode = 'rb'):
+                        return path
+                except:
+                     pass
+            await asyncio.sleep(0.1)
+            timeout_sec -= 0.1
+        return None
+
+
+class CtrlCmdUtil:
+    """
+    EpgTimerSrv の CtrlCmd インタフェースと通信する (EDCB/EpgTimer の CtrlCmd(Def).cs を移植したもの)
+    ・利用可能なコマンドはもっとあるが使いそうなものだけ
+    ・sendView* 系コマンドは EpgDataCap_Bon 等との通信用。接続先パイプは "View_Ctrl_BonNoWaitPipe_{プロセス ID}"
+    """
+
+    # EDCB の日付は OS のタイムゾーンに関わらず常に UTC+9
+    TZ = datetime.timezone(datetime.timedelta(hours = 9), 'JST')
+
+    def __init__(self) -> None:
+        self.__connect_timeout_sec = 15.
+        self.__pipe_name = 'EpgTimerSrvNoWaitPipe'
+        self.__host: Optional[str] = None
+        self.__port = 0
+
+    def setPipeSetting(self, name: str) -> None:
+        """ 名前付きパイプモードにする """
+        self.__pipe_name = name
+        self.__host = None
+
+    def pipeExists(self) -> bool:
+        """ 接続先パイプが存在するか調べる """
+        try:
+            with open('\\\\.\\pipe\\' + self.__pipe_name, mode = 'r+b'):
+                pass
+        except FileNotFoundError:
+            return False
+        except:
+             pass
+        return True
+
+    def setNWSetting(self, host: str, port: int) -> None:
+        """ TCP/IP モードにする """
+        self.__host = host
+        self.__port = port
+
+    def setConnectTimeOutSec(self, timeout: float) -> None:
+        """ 接続処理時のタイムアウト設定 """
+        self.__connect_timeout_sec = timeout
+
+    async def sendViewSetBonDriver(self, name: str) -> bool:
+        """ BonDriver の切り替え """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_VIEW_APP_SET_BONDRIVER)
+        self.__writeInt(buf, 0)
+        self.__writeString(buf, name)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        return ret == self.__CMD_SUCCESS
+
+    async def sendViewGetBonDriver(self) -> Optional[str]:
+        """ 使用中の BonDriver のファイル名を取得 """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_VIEW_APP_GET_BONDRIVER)
+        self.__writeInt(buf, 0)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            return self.__readString(memoryview(buf), [0], len(buf))
+        return None
+
+    async def sendViewSetCh(self, set_ch_info: dict) -> bool:
+        """ チャンネル切り替え """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_VIEW_APP_SET_CH)
+        self.__writeInt(buf, 0)
+        self.__writeSetChInfo(buf, set_ch_info)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        return ret == self.__CMD_SUCCESS
+
+    async def sendViewAppClose(self) -> bool:
+        """ アプリケーションの終了 """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_VIEW_APP_CLOSE)
+        self.__writeInt(buf, 0)
+        ret, buf = await self.__sendAndReceive(buf)
+        return ret == self.__CMD_SUCCESS
+
+    async def sendEnumService(self) -> Optional[list]:
+        """ サービス一覧を取得する """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_SERVICE)
+        self.__writeInt(buf, 0)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            return self.__readVector(self.__readServiceInfo, memoryview(buf), [0], len(buf))
+        return None
+
+    async def sendEnumPgInfoEx(self, service_time_list: list) -> Optional[list]:
+        """ サービス指定と時間指定で番組情報一覧を取得する """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_PG_INFO_EX)
+        self.__writeInt(buf, 0)
+        self.__writeVector(self.__writeLong, buf, service_time_list)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            return self.__readVector(self.__readServiceEventInfo, memoryview(buf), [0], len(buf))
+        return None
+
+    async def sendEnumPgArc(self, service_time_list: list) -> Optional[list]:
+        """ サービス指定と時間指定で過去番組情報一覧を取得する """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_PG_ARC)
+        self.__writeInt(buf, 0)
+        self.__writeVector(self.__writeLong, buf, service_time_list)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            return self.__readVector(self.__readServiceEventInfo, memoryview(buf), [0], len(buf))
+        return None
+
+    async def sendFileCopy(self, name: str) -> Optional[bytes]:
+        """ 指定ファイルを転送する """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_EPG_SRV_FILE_COPY)
+        self.__writeInt(buf, 0)
+        self.__writeString(buf, name)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            return buf
+        return None
+
+    async def sendFileCopy2(self, name_list: list) -> Optional[list]:
+        """ 指定ファイルをまとめて転送する """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD2_EPG_SRV_FILE_COPY2)
+        self.__writeInt(buf, 0)
+        self.__writeUshort(buf, self.__CMD_VER)
+        self.__writeVector(self.__writeString, buf, name_list)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            bufview = memoryview(buf)
+            pos = [0]
+            if (ver := self.__readUshort(bufview, pos, len(buf))) is not None and ver >= self.__CMD_VER:
+                return self.__readVector(self.__readFileData, bufview, pos, len(buf))
+        return None
+
+    async def sendNwTVIDSetCh(self, set_ch_info: dict) -> Optional[int]:
+        """ NetworkTV モードの View アプリのチャンネルを切り替え、または起動の確認 (ID 指定) """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_EPG_SRV_NWTV_ID_SET_CH)
+        self.__writeInt(buf, 0)
+        self.__writeSetChInfo(buf, set_ch_info)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            return self.__readInt(memoryview(buf), [0], len(buf))
+        return None
+
+    async def sendNwTVIDClose(self, nwtv_id: int) -> bool:
+        """ NetworkTV モードで起動中の View アプリを終了 (ID 指定) """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_EPG_SRV_NWTV_ID_CLOSE)
+        self.__writeInt(buf, 0)
+        self.__writeInt(buf, nwtv_id)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        return ret == self.__CMD_SUCCESS
+
+    async def sendEnumRecInfoBasic2(self) -> Optional[list]:
+        """ 録画済み情報一覧取得 (programInfo と errInfo を除く) """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_RECINFO_BASIC2)
+        self.__writeInt(buf, 0)
+        self.__writeUshort(buf, self.__CMD_VER)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            bufview = memoryview(buf)
+            pos = [0]
+            if (ver := self.__readUshort(bufview, pos, len(buf))) is not None and ver >= self.__CMD_VER:
+                return self.__readVector(self.__readRecFileInfo, bufview, pos, len(buf))
+        return None
+
+    async def sendGetRecInfo2(self, info_id: int) -> Optional[dict]:
+        """ 録画済み情報取得 """
+        buf = bytearray()
+        self.__writeInt(buf, self.__CMD_EPG_SRV_GET_RECINFO2)
+        self.__writeInt(buf, 0)
+        self.__writeUshort(buf, self.__CMD_VER)
+        self.__writeInt(buf, info_id)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        ret, buf = await self.__sendAndReceive(buf)
+        if ret == self.__CMD_SUCCESS:
+            bufview = memoryview(buf)
+            pos = [0]
+            if (ver := self.__readUshort(bufview, pos, len(buf))) is not None and ver >= self.__CMD_VER:
+                return self.__readRecFileInfo(bufview, pos, len(buf))
+        return None
+
+    # EDCB/EpgTimer の CtrlCmd.cs より
+    __CMD_SUCCESS = 1
+    __CMD_VER = 5
+    __CMD_VIEW_APP_SET_BONDRIVER = 201
+    __CMD_VIEW_APP_GET_BONDRIVER = 202
+    __CMD_VIEW_APP_SET_CH = 205
+    __CMD_VIEW_APP_CLOSE = 208
+    __CMD_EPG_SRV_ENUM_SERVICE = 1021
+    __CMD_EPG_SRV_ENUM_PG_INFO_EX = 1029
+    __CMD_EPG_SRV_ENUM_PG_ARC = 1030
+    __CMD_EPG_SRV_FILE_COPY = 1060
+    __CMD_EPG_SRV_NWTV_ID_SET_CH = 1073
+    __CMD_EPG_SRV_NWTV_ID_CLOSE = 1074
+    __CMD_EPG_SRV_ENUM_RECINFO_BASIC2 = 2020
+    __CMD_EPG_SRV_GET_RECINFO2 = 2024
+    __CMD2_EPG_SRV_FILE_COPY2 = 2060
+
+    async def __sendAndReceive(self, buf: bytearray):
+        to = time.monotonic() + self.__connect_timeout_sec
+        if self.__host is None:
+            # 名前付きパイプモード
+            while True:
+                try:
+                    with open('\\\\.\\pipe\\' + self.__pipe_name, mode = 'r+b') as f:
+                        f.write(buf)
+                        f.flush()
+                        rbuf = f.read(8)
+                        if len(rbuf) == 8:
+                            bufview = memoryview(rbuf)
+                            pos = [0]
+                            ret = self.__readInt(bufview, pos, 8)
+                            size = self.__readInt(bufview, pos, 8)
+                            rbuf = f.read(size)
+                            if len(rbuf) == size:
+                                    return ret, rbuf
+                    break
+                except FileNotFoundError:
+                    break
+                except:
+                    pass
+                await asyncio.sleep(0.01)
+                if time.monotonic() >= to:
+                    break
+            return None, None
+
+        # TCP/IP モード
+        try:
+            r, w = await asyncio.wait_for(asyncio.open_connection(self.__host, self.__port), max(to - time.monotonic(), 0.))
+        except:
+            return None, None
+        try:
+            w.write(buf)
+            await asyncio.wait_for(w.drain(), max(to - time.monotonic(), 0.))
+            rbuf = await asyncio.wait_for(r.readexactly(8), max(to - time.monotonic(), 0.))
+            if len(rbuf) == 8:
+                bufview = memoryview(rbuf)
+                pos = [0]
+                ret = self.__readInt(bufview, pos, 8)
+                size = self.__readInt(bufview, pos, 8)
+                rbuf = await asyncio.wait_for(r.readexactly(size), max(to - time.monotonic(), 0.))
+        except:
+            w.close()
+            return None, None
+        try:
+            w.close()
+            await asyncio.wait_for(w.wait_closed(), max(to - time.monotonic(), 0.))
+        except:
+            pass
+        if len(rbuf) == size:
+            return ret, rbuf
+        return None, None
+
+    @staticmethod
+    def __writeByte(buf: bytearray, v: int) -> None:
+        buf.extend(v.to_bytes(1, 'little'))
+
+    @staticmethod
+    def __writeUshort(buf: bytearray, v: int) -> None:
+        buf.extend(v.to_bytes(2, 'little'))
+
+    @staticmethod
+    def __writeInt(buf: bytearray, v: int) -> None:
+        buf.extend(v.to_bytes(4, 'little', signed = True))
+
+    @staticmethod
+    def __writeLong(buf: bytearray, v: int) -> None:
+        buf.extend(v.to_bytes(8, 'little', signed = True))
+
+    @staticmethod
+    def __writeIntInplace(buf: bytearray, pos: int, v: int) -> None:
+        buf[pos:pos + 4] = v.to_bytes(4, 'little', signed = True)
+
+    @classmethod
+    def __writeString(cls, buf: bytearray, v: str) -> None:
+        vv = v.encode('utf_16_le')
+        cls.__writeInt(buf, 6 + len(vv))
+        buf.extend(vv)
+        cls.__writeUshort(buf, 0)
+
+    @classmethod
+    def __writeVector(cls, write_func: Callable, buf: bytearray, v: list) -> None:
+        pos = len(buf)
+        cls.__writeInt(buf, 0)
+        cls.__writeInt(buf, len(v))
+        for e in v:
+            write_func(buf, e)
+        cls.__writeIntInplace(buf, pos, len(buf) - pos)
+
+    # 以下、各構造体のライター
+    # 各キーの意味は CtrlCmdDef.cs のクラス定義を参照のこと
+
+    @classmethod
+    def __writeSetChInfo(cls, buf: bytearray, v: dict) -> None:
+        pos = len(buf)
+        cls.__writeInt(buf, 0)
+        cls.__writeInt(buf, 1 if v.get('use_sid') else 0)
+        cls.__writeUshort(buf, v.get('onid', 0))
+        cls.__writeUshort(buf, v.get('tsid', 0))
+        cls.__writeUshort(buf, v.get('sid', 0))
+        cls.__writeInt(buf, 1 if v.get('use_bon_ch') else 0)
+        cls.__writeInt(buf, v.get('space_or_id', 0))
+        cls.__writeInt(buf, v.get('ch_or_mode', 0))
+        cls.__writeIntInplace(buf, pos, len(buf) - pos)
+
+    @staticmethod
+    def __readByte(buf: memoryview, pos: list, size: int, dest: Optional[dict] = None, key: Optional[str] = None):
+        if size - pos[0] < 1:
+            return None if dest is None else False
+        v = int.from_bytes(buf[pos[0]:pos[0] + 1], 'little')
+        pos[0] += 1
+        if dest is None:
+            return v
+        dest[key] = v
+        return True
+
+    @staticmethod
+    def __readUshort(buf: memoryview, pos: list, size: int, dest: Optional[dict] = None, key: Optional[str] = None):
+        if size - pos[0] < 2:
+            return None if dest is None else False
+        v = int.from_bytes(buf[pos[0]:pos[0] + 2], 'little')
+        pos[0] += 2
+        if dest is None:
+            return v
+        dest[key] = v
+        return True
+
+    @staticmethod
+    def __readInt(buf: memoryview, pos: list, size: int, dest: Optional[dict] = None, key: Optional[str] = None):
+        if size - pos[0] < 4:
+            return None if dest is None else False
+        v = int.from_bytes(buf[pos[0]:pos[0] + 4], 'little', signed = True)
+        pos[0] += 4
+        if dest is None:
+            return v
+        dest[key] = v
+        return True
+
+    @staticmethod
+    def __readLong(buf: memoryview, pos: list, size: int, dest: Optional[dict] = None, key: Optional[str] = None):
+        if size - pos[0] < 8:
+            return None if dest is None else False
+        v = int.from_bytes(buf[pos[0]:pos[0] + 8], 'little', signed = True)
+        pos[0] += 8
+        if dest is None:
+            return v
+        dest[key] = v
+        return True
+
+    @classmethod
+    def __readSystemTime(cls, buf: memoryview, pos: list, size: int, dest: Optional[dict] = None, key: Optional[str] = None):
+        if size - pos[0] < 16:
+            return None if dest is None else False
+        try:
+            v = datetime.datetime(int.from_bytes(buf[pos[0]:pos[0] + 2], 'little'),
+                                  int.from_bytes(buf[pos[0] + 2:pos[0] + 4], 'little'),
+                                  int.from_bytes(buf[pos[0] + 6:pos[0] + 8], 'little'),
+                                  int.from_bytes(buf[pos[0] + 8:pos[0] + 10], 'little'),
+                                  int.from_bytes(buf[pos[0] + 10:pos[0] + 12], 'little'),
+                                  int.from_bytes(buf[pos[0] + 12:pos[0] + 14], 'little'),
+                                  tzinfo = cls.TZ)
+        except:
+            v = datetime.datetime.min
+        pos[0] += 16
+        if dest is None:
+            return v
+        dest[key] = v
+        return True
+
+    @classmethod
+    def __readString(cls, buf: memoryview, pos: list, size: int, dest: Optional[dict] = None, key: Optional[str] = None):
+        vs = cls.__readInt(buf, pos, size)
+        if vs is None or vs < 6 or size - pos[0] < vs - 4:
+            return None if dest is None else False
+        v = str(buf[pos[0]:pos[0] + vs - 6], 'utf_16_le')
+        pos[0] += vs - 4
+        if dest is None:
+            return v
+        dest[key] = v
+        return True
+
+    @classmethod
+    def __readVector(cls, read_func: Callable, buf: memoryview, pos: list, size: int, dest: Optional[dict] = None, key: Optional[str] = None):
+        if ((vs := cls.__readInt(buf, pos, size)) is None or
+            (vc := cls.__readInt(buf, pos, size)) is None or
+            vs < 8 or vc < 0 or size - pos[0] < vs - 8):
+            return None if dest is None else False
+        size = pos[0] + vs - 8
+        v = []
+        for i in range(vc):
+            e = read_func(buf, pos, size)
+            if e is None:
+                return None if dest is None else False
+            v.append(e)
+        pos[0] = size
+        if dest is None:
+            return v
+        dest[key] = v
+        return True
+
+    @classmethod
+    def __readStructIntro(cls, buf: memoryview, pos: list, size: int):
+        vs = cls.__readInt(buf, pos, size)
+        if vs is None or vs < 4 or size - pos[0] < vs - 4:
+            return None, 0
+        return {}, pos[0] + vs - 4
+
+    # 以下、各構造体のリーダー
+    # 各キーの意味は CtrlCmdDef.cs のクラス定義を参照のこと
+
+    @classmethod
+    def __readFileData(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readString(buf, pos, size, v, 'name') or
+            (data_size := cls.__readInt(buf, pos, size)) is None or
+            cls.__readInt(buf, pos, size) is None or
+            data_size < 0 or size - pos[0] < data_size):
+            return None
+        v['data'] = bytes(buf[pos[0]:pos[0] + data_size])
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readRecFileInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readInt(buf, pos, size, v, 'id') or
+            not cls.__readString(buf, pos, size, v, 'rec_file_path') or
+            not cls.__readString(buf, pos, size, v, 'title') or
+            not cls.__readSystemTime(buf, pos, size, v, 'start_time') or
+            not cls.__readInt(buf, pos, size, v, 'duration_sec') or
+            not cls.__readString(buf, pos, size, v, 'service_name') or
+            not cls.__readUshort(buf, pos, size, v, 'onid') or
+            not cls.__readUshort(buf, pos, size, v, 'tsid') or
+            not cls.__readUshort(buf, pos, size, v, 'sid') or
+            not cls.__readUshort(buf, pos, size, v, 'eid') or
+            not cls.__readLong(buf, pos, size, v, 'drops') or
+            not cls.__readLong(buf, pos, size, v, 'scrambles') or
+            not cls.__readInt(buf, pos, size, v, 'rec_status') or
+            not cls.__readSystemTime(buf, pos, size, v, 'start_time_epg') or
+            not cls.__readString(buf, pos, size, v, 'comment') or
+            not cls.__readString(buf, pos, size, v, 'program_info') or
+            not cls.__readString(buf, pos, size, v, 'err_info') or
+            not cls.__readByte(buf, pos, size, v, 'protect_flag')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readServiceEventInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if v is None:
+            return None
+        v['service_info'] = cls.__readServiceInfo(buf, pos, size)
+        if (v['service_info'] is None or
+            not cls.__readVector(cls.__readEventInfo, buf, pos, size, v, 'event_list')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readServiceInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readUshort(buf, pos, size, v, 'onid') or
+            not cls.__readUshort(buf, pos, size, v, 'tsid') or
+            not cls.__readUshort(buf, pos, size, v, 'sid') or
+            not cls.__readByte(buf, pos, size, v, 'service_type') or
+            not cls.__readByte(buf, pos, size, v, 'partial_reception_flag') or
+            not cls.__readString(buf, pos, size, v, 'service_provider_name') or
+            not cls.__readString(buf, pos, size, v, 'service_name') or
+            not cls.__readString(buf, pos, size, v, 'network_name') or
+            not cls.__readString(buf, pos, size, v, 'ts_name') or
+            not cls.__readByte(buf, pos, size, v, 'remote_control_key_id')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readEventInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readUshort(buf, pos, size, v, 'onid') or
+            not cls.__readUshort(buf, pos, size, v, 'tsid') or
+            not cls.__readUshort(buf, pos, size, v, 'sid') or
+            not cls.__readUshort(buf, pos, size, v, 'eid') or
+            (start_time_flag := cls.__readByte(buf, pos, size)) is None or
+            not cls.__readSystemTime(buf, pos, size, v, 'start_time') or
+            (duration_flag := cls.__readByte(buf, pos, size)) is None or
+            not cls.__readInt(buf, pos, size, v, 'duration_sec')):
+            return None
+
+        if start_time_flag == 0:
+            del v['start_time']
+        if duration_flag == 0:
+            del v['duration_sec']
+
+        if (n := cls.__readInt(buf, pos, size)) is None:
+            return None
+        if n != 4:
+            pos[0] -= 4
+            v['short_info'] = cls.__readShortEventInfo(buf, pos, size);
+            if v['short_info'] is None:
+                return None
+
+        if (n := cls.__readInt(buf, pos, size)) is None:
+            return None
+        if n != 4:
+            pos[0] -= 4
+            v['ext_info'] = cls.__readExtendedEventInfo(buf, pos, size);
+            if v['ext_info'] is None:
+                return None
+
+        if (n := cls.__readInt(buf, pos, size)) is None:
+            return None
+        if n != 4:
+            pos[0] -= 4
+            v['content_info'] = cls.__readContentInfo(buf, pos, size);
+            if v['content_info'] is None:
+                return None
+
+        if (n := cls.__readInt(buf, pos, size)) is None:
+            return None
+        if n != 4:
+            pos[0] -= 4
+            v['component_info'] = cls.__readComponentInfo(buf, pos, size);
+            if v['component_info'] is None:
+                return None
+
+        if (n := cls.__readInt(buf, pos, size)) is None:
+            return None
+        if n != 4:
+            pos[0] -= 4
+            v['audio_info'] = cls.__readAudioComponentInfo(buf, pos, size);
+            if v['audio_info'] is None:
+                return None
+
+        if (n := cls.__readInt(buf, pos, size)) is None:
+            return None
+        if n != 4:
+            pos[0] -= 4
+            v['event_group_info'] = cls.__readEventGroupInfo(buf, pos, size);
+            if v['event_group_info'] is None:
+                return None
+
+        if (n := cls.__readInt(buf, pos, size)) is None:
+            return None
+        if n != 4:
+            pos[0] -= 4
+            v['event_relay_info'] = cls.__readEventGroupInfo(buf, pos, size);
+            if v['event_relay_info'] is None:
+                return None
+
+        if not cls.__readByte(buf, pos, size, v, 'free_ca_flag'):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readShortEventInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readString(buf, pos, size, v, 'event_name') or
+            not cls.__readString(buf, pos, size, v, 'text_char')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readExtendedEventInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readString(buf, pos, size, v, 'text_char')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readContentInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readVector(cls.__readContentData, buf, pos, size, v, 'nibble_list')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readContentData(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            (cn := cls.__readUshort(buf, pos, size)) is None or
+            (un := cls.__readUshort(buf, pos, size)) is None):
+            return None
+        v['content_nibble'] = (cn >> 8 | cn << 8) & 0xffff
+        v['user_nibble'] = (un >> 8 | un << 8) & 0xffff
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readComponentInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readByte(buf, pos, size, v, 'stream_content') or
+            not cls.__readByte(buf, pos, size, v, 'component_type') or
+            not cls.__readByte(buf, pos, size, v, 'component_tag') or
+            not cls.__readString(buf, pos, size, v, 'text_char')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readAudioComponentInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readVector(cls.__readAudioComponentInfoData, buf, pos, size, v, 'component_list')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readAudioComponentInfoData(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readByte(buf, pos, size, v, 'stream_content') or
+            not cls.__readByte(buf, pos, size, v, 'component_type') or
+            not cls.__readByte(buf, pos, size, v, 'component_tag') or
+            not cls.__readByte(buf, pos, size, v, 'stream_type') or
+            not cls.__readByte(buf, pos, size, v, 'simulcast_group_tag') or
+            not cls.__readByte(buf, pos, size, v, 'es_multi_lingual_flag') or
+            not cls.__readByte(buf, pos, size, v, 'main_component_flag') or
+            not cls.__readByte(buf, pos, size, v, 'quality_indicator') or
+            not cls.__readByte(buf, pos, size, v, 'sampling_rate') or
+            not cls.__readString(buf, pos, size, v, 'text_char')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readEventGroupInfo(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readByte(buf, pos, size, v, 'group_type') or
+            not cls.__readVector(cls.__readEventData, buf, pos, size, v, 'event_data_list')):
+            return None
+        pos[0] = size
+        return v
+
+    @classmethod
+    def __readEventData(cls, buf: memoryview, pos: list, size: int) -> Optional[dict]:
+        v, size = cls.__readStructIntro(buf, pos, size)
+        if (v is None or
+            not cls.__readUshort(buf, pos, size, v, 'onid') or
+            not cls.__readUshort(buf, pos, size, v, 'tsid') or
+            not cls.__readUshort(buf, pos, size, v, 'sid') or
+            not cls.__readUshort(buf, pos, size, v, 'eid')):
+            return None
+        pos[0] = size
+        return v


### PR DESCRIPTION
EDCB (xtne6f, tkntrec 系) 対応のパッチを作ってみたのでよければお使いください。

`server/app/utils/EDCB.py` については半ばライブラリ的にそのままマージしてもらおうという方針で書きましたが、ほかの部分はサンプルコードのようなものなのでプロジェクトの方針に合わせて自由に上書きしてください。

config.yaml のバックエンド設定を `'backend': 'EDCB'` とすれば挙動を EDCB 向けに変更します。
`edcb_host` と `edcb_port` 設定については、今のところ EDCB と Konomi が同一 PC にあることを仮定しているので変更不要です。

ロゴ画像は EpgDataCap_Bon 設定の「ロゴデータを保存する」で受信したロゴを取得できるようにしています。ロゴ取得は EpgTimerSrv 設定の「EpgTimerSrv の応答を tkntrec 版互換にする」を有効にする必要があります ([tkntrec 版]( https://github.com/tkntrec/EDCB )では既定で有効)。古めの EpgDataCap_Bon では一部チャンネルのロゴが受信できなかったりすると思うので、そのときは新しいものを使ってみてください。

ライブストリーム機能は [EDCB_Material_WebUI]( https://github.com/EMWUI/EDCB_Material_WebUI ) などで利用されている「NetworkTVモード」という EDCB の視聴機能を用いて実装しました。
この機能を利用するにあたって必要な EDCB 側の設定が現状2つあって

1. EpgTimerSrv 設定の「視聴に使用する BonDriver」に BonDriver を追加
2. EpgDataCap_Bon 設定の「TCP 送信」に SrvPipe (0.0.0.1) を追加 (ポートは 0)

です。うまくいけば EpgTimerSrv プロセスを介して EpgDataCap_Bon が起動し視聴できるはずです (ただし予約が優先されます)。